### PR TITLE
Make this cookbook compatible with Chef 12

### DIFF
--- a/.octopolo.yml
+++ b/.octopolo.yml
@@ -1,0 +1,2 @@
+deploy_branch: master
+github_repo: sportngin-cookbooks/opsworks-bashrc

--- a/libraries/helper_methods.rb
+++ b/libraries/helper_methods.rb
@@ -16,7 +16,7 @@ module OpsworksBashrc
       end
     end
 
-    def app_settings
+    def instance_data
       if node[:opsworks]
         { layers: node[:opsworks][:instance][:layers],
           private_ip: node[:opsworks][:instance][:private_ip],

--- a/libraries/helper_methods.rb
+++ b/libraries/helper_methods.rb
@@ -16,5 +16,26 @@ module OpsworksBashrc
       end
     end
 
+    def app_settings
+      if node[:opsworks]
+        { layers: node[:opsworks][:instance][:layers],
+          private_ip: node[:opsworks][:instance][:private_ip],
+          hostname: node[:opsworks][:instance][:hostname],
+          box_type: node[:opsworks][:instance][:instance_type],
+          node_id: node[:opsworks][:instance][:aws_instance_id],
+          zone: node[:opsworks][:instance][:availability_zone]
+        }
+      else
+        instance = search("aws_opsworks_instance", "self:true").first
+
+        { layers: instance['layer_ids'],
+          private_ip: instance['private_ip'],
+          hostname: instance['hostname'],
+          box_type: instance['instance_type'],
+          node_id: instance['instance_id'],
+          zone: instance['availability_zone']
+        }
+      end
+    end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,26 +21,7 @@ template "/etc/profile.d/custom_bashrc.sh" do
   owner "root"
   group "root"
   mode 0644
-
-  if node[:opsworks]
-    settings = { layers: node[:opsworks][:instance][:layers],
-                 private_ip: node[:opsworks][:instance][:private_ip],
-                 hostname: node[:opsworks][:instance][:hostname],
-                 box_type: node[:opsworks][:instance][:instance_type],
-                 node_id: node[:opsworks][:instance][:aws_instance_id],
-                 zone: node[:opsworks][:instance][:availability_zone]
-               }
-  else
-    instance = search("aws_opsworks_instance").first
-
-    settings = { layers: instance['layer_ids'],
-                 private_ip: instance['private_ip'],
-                 hostname: instance['hostname'],
-                 box_type: instance['instance_type'],
-                 node_id: instance['instance_id'],
-                 zone: instance['availability_zone']
-               }
-  end
+  settings = app_settings
 
   variables({
     :appdir => app_dir,

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,16 +21,16 @@ template "/etc/profile.d/custom_bashrc.sh" do
   owner "root"
   group "root"
   mode 0644
-  settings = app_settings
+  data = instance_data
 
   variables({
     :appdir => app_dir,
-    :layers => settings[:layers],
-    :private_ip => settings[:private_ip],
-    :hostname => settings[:hostname],
-    :box_type => settings[:box_type],
-    :node_id => settings[:node_id],
-    :zone => settings[:zone],
+    :layers => data[:layers],
+    :private_ip => data[:private_ip],
+    :hostname => data[:hostname],
+    :box_type => data[:box_type],
+    :node_id => data[:node_id],
+    :zone => data[:zone],
     :custom_env_variables => node.fetch(:opsworks_bashrc, {}).fetch(:custom_env_variables, {}),
     :custom_bash_aliases => node.fetch(:opsworks_bashrc, {}).fetch(:custom_bash_aliases, {}),
     :custom_bash_scripts => node.fetch(:opsworks_bashrc, {}).fetch(:custom_bash_scripts, []),

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,14 +21,35 @@ template "/etc/profile.d/custom_bashrc.sh" do
   owner "root"
   group "root"
   mode 0644
+
+  if node[:opsworks]
+    settings = { layers: node[:opsworks][:instance][:layers],
+                 private_ip: node[:opsworks][:instance][:private_ip],
+                 hostname: node[:opsworks][:instance][:hostname],
+                 box_type: node[:opsworks][:instance][:instance_type],
+                 node_id: node[:opsworks][:instance][:aws_instance_id],
+                 zone: node[:opsworks][:instance][:availability_zone]
+               }
+  else
+    instance = search("aws_opsworks_instance").first
+
+    settings = { layers: instance['layer_ids'],
+                 private_ip: instance['private_ip'],
+                 hostname: instance['hostname'],
+                 box_type: instance['instance_type'],
+                 node_id: instance['instance_id'],
+                 zone: instance['availability_zone']
+               }
+  end
+
   variables({
     :appdir => app_dir,
-    :layers => node[:opsworks][:instance][:layers],
-    :private_ip => node[:opsworks][:instance][:private_ip],
-    :hostname => node[:opsworks][:instance][:hostname],
-    :box_type => node[:opsworks][:instance][:instance_type],
-    :node_id => node[:opsworks][:instance][:aws_instance_id],
-    :zone => node[:opsworks][:instance][:availability_zone],
+    :layers => settings[:layers],
+    :private_ip => settings[:private_ip],
+    :hostname => settings[:hostname],
+    :box_type => settings[:box_type],
+    :node_id => settings[:node_id],
+    :zone => settings[:zone],
     :custom_env_variables => node.fetch(:opsworks_bashrc, {}).fetch(:custom_env_variables, {}),
     :custom_bash_aliases => node.fetch(:opsworks_bashrc, {}).fetch(:custom_bash_aliases, {}),
     :custom_bash_scripts => node.fetch(:opsworks_bashrc, {}).fetch(:custom_bash_scripts, []),


### PR DESCRIPTION
What
----------------------
Allow this cookbook to work with stacks that are running Chef 12.

Why
----------------------
Because we may eventually want to switch over to Chef 12.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://sportngin.atlassian.net/browse/IS-6817

QA Plan
-------
- [x] Run `opsworks-bashrc::default` on a stack with Chef 12 and see if it works